### PR TITLE
Make the version input optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,9 @@ inputs:
     default: ${{ github.event.repository.name }}
   version:
     description: The version number of the release
-    required: true
+    required: false
     type: string
+    default: ${{ github.ref_name }}
   zip-path:
     description: The path to the plugin zip file
     required: true

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,6 @@ Within the GitHub Actions workflow which deploys your plugin to WordPress.org:
    - uses: johnbillion/action-wordpress-plugin-attestation@0.4.0
      with:
        plugin: my-plugin-slug
-       version: 1.2.3
        zip-path: my-plugin-slug.zip
    ```
 
@@ -61,14 +60,12 @@ jobs:
         env:
           SVN_USERNAME: ${{ secrets.WPORG_SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.WPORG_SVN_PASSWORD }}
-          VERSION: ${{ inputs.version }}
         with:
           generate-zip: true
       - name: Attest build provenance
         uses: johnbillion/action-wordpress-plugin-attestation@0.4.0
         with:
           plugin: my-plugin-slug
-          version: ${{ inputs.version }}
           zip-path: ${{ steps.deploy.outputs.zip-path }}
 ```
 
@@ -117,7 +114,6 @@ Yes, but be aware that when a consumer verifies an attestation they need to use 
 
 ## TODO
 
-* Make the `version` input parameter optional
 * Add support for arbitrary remote hosts in addition to wordpress.org
 * Consider how attestations can be used as part of workflows for installing and deploying plugins
   - WP-CLI

--- a/readme.md
+++ b/readme.md
@@ -34,12 +34,8 @@ Within the GitHub Actions workflow which deploys your plugin to WordPress.org:
    ```yaml
    - uses: johnbillion/action-wordpress-plugin-attestation@0.4.0
      with:
-       plugin: my-plugin-slug
        zip-path: my-plugin-slug.zip
    ```
-
-> [!WARNING]
-> In order to support [plugin release confirmation](https://developer.wordpress.org/plugins/wordpress-org/release-confirmation-emails/) this action will attempt to fetch the zip file from WordPress.org for up to 60 minutes. You can adjust this via the `timeout` input parameter.
 
 ## Example workflow
 
@@ -65,8 +61,31 @@ jobs:
       - name: Attest build provenance
         uses: johnbillion/action-wordpress-plugin-attestation@0.4.0
         with:
-          plugin: my-plugin-slug
           zip-path: ${{ steps.deploy.outputs.zip-path }}
+```
+
+## Inputs
+
+Here is the full list of required and optional inputs:
+
+```yaml
+- uses: johnbillion/action-wordpress-plugin-attestation@0.4.0
+  with:
+    # Required. Path to the ZIP file generated for the plugin release.
+    # Use something like `${{ steps.deploy.outputs.zip-path }}` if you're using the WordPress Plugin Deploy action by 10up.
+    zip-path: my-plugin-slug.zip
+
+    # Optional. Plugin slug name. Defaults to the repo name.
+    plugin: my-plugin-slug
+
+    # Optional. Plugin version number. Defaults to the tag name if the workflow was triggered for a tag or a release.
+    version: 1.2.3
+
+    # Optional. Maximum time in minutes to spend trying to fetch the ZIP from WordPress.org.
+    timeout: 60
+
+    # Optional. Whether to perform a dry-run which runs everything except the actual attestation step.
+    dry-run: false
 ```
 
 ## Why wouldn't I just generate the attestation directly with `actions/attest-build-provenance`?

--- a/readme.md
+++ b/readme.md
@@ -72,13 +72,13 @@ Here is the full list of required and optional inputs:
 - uses: johnbillion/action-wordpress-plugin-attestation@0.4.0
   with:
     # Required. Path to the ZIP file generated for the plugin release.
-    # Use something like `${{ steps.deploy.outputs.zip-path }}` if you're using the WordPress Plugin Deploy action by 10up.
+    # Use `${{ steps.deploy.outputs.zip-path }}` if you're using the WordPress Plugin Deploy action by 10up.
     zip-path: my-plugin-slug.zip
 
     # Optional. Plugin slug name. Defaults to the repo name.
     plugin: my-plugin-slug
 
-    # Optional. Plugin version number. Defaults to the tag name if the workflow was triggered for a tag or a release.
+    # Optional. Plugin version number. Defaults to the tag name if triggered by pushing a tag or a release.
     version: 1.2.3
 
     # Optional. Maximum time in minutes to spend trying to fetch the ZIP from WordPress.org.


### PR DESCRIPTION
The value should default to the tag name when a tag or release is pushed.